### PR TITLE
Completely ignore error message from AuthCanceled.

### DIFF
--- a/social/apps/django_app/middleware.py
+++ b/social/apps/django_app/middleware.py
@@ -7,7 +7,7 @@ from django.contrib.messages.api import MessageFailure
 from django.shortcuts import redirect
 from django.utils.http import urlquote
 
-from social.exceptions import SocialAuthBaseException
+from social.exceptions import SocialAuthBaseException, AuthCanceled
 from social.utils import social_logger
 
 
@@ -32,7 +32,8 @@ class SocialAuthExceptionMiddleware(object):
             backend_name = getattr(backend, 'name', 'unknown-backend')
 
             message = self.get_message(request, exception)
-            social_logger.error(message)
+            if not isinstance(exception, AuthCanceled):
+                social_logger.error(message)
 
             url = self.get_redirect_uri(request, exception)
             try:


### PR DESCRIPTION
## Purpose
We don't care about the error message 'Authentication process canceled'. It results from a relatively normal user process in which the user decides after choosing to do social auth not to actually login with the social auth provider. This message appears every few days and does nothing except clog our logs. With that said, we don't want to ignore ALL social errors, just this one in particular. 

## What the code does
Adds a logical branch to avoid logging the specific `AuthCanceled` exception.